### PR TITLE
Using React\Stream instead of polling

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,9 +108,6 @@
         wSocket.onopen = function (event) {
           console.log("Socket Open");
           term.attach(wSocket,false,false);
-          window.setInterval(function(){
-            wSocket.send(JSON.stringify({"refresh":""}));
-          }, 700);
         };
 
         wSocket.onerror = function (event){


### PR DESCRIPTION
Using React\Stream instead of polling allows direct the shell's output stream directly to the websocket.